### PR TITLE
Add optional line width prop to define stroke width of the circle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ import Circle from 'react-circle';
 
 <Circle
   size={150}
+  lineWidth={14}
   progress={69}
   progressColor="cornflowerblue"
   bgColor="whitesmoke"

--- a/example/app.tsx
+++ b/example/app.tsx
@@ -11,9 +11,10 @@ export interface AppState {
   bgColor: string;
   textColor: string;
   size: string;
+  lineWidth: string;
 }
 
-export type StatePropName = 'progressColor' | 'bgColor' | 'textColor' | 'size';
+export type StatePropName = 'progressColor' | 'bgColor' | 'textColor' | 'size' | 'lineWidth';
 
 export default class App extends Component <{}, AppState> {
   state: AppState = {
@@ -21,9 +22,10 @@ export default class App extends Component <{}, AppState> {
     progressColor: '#F7DC1B',
     bgColor: '#54BAD8',
     textColor: 'hotpink',
-    size: '200'
+    size: '200',
+    lineWidth: `30`
   }
-  
+
   onTextFieldChange = (propName: StatePropName) => (e: any) => {
     this.setState({[propName]: e.target.value} as any);
   }
@@ -33,7 +35,7 @@ export default class App extends Component <{}, AppState> {
   }
 
   render() {
-    const {progress, progressColor, bgColor, textColor, size} = this.state;
+    const {progress, progressColor, bgColor, textColor, size, lineWidth} = this.state;
 
     return (
       <AppWrapper>
@@ -50,6 +52,7 @@ export default class App extends Component <{}, AppState> {
           </div>
           <TextFieldsWrapper>
             <TextField value={size} label="width" onChange={this.onTextFieldChange('size')} />
+            <TextField value={lineWidth} label="line width" onChange={this.onTextFieldChange('lineWidth')} />
             <TextField value={progressColor} label="progress color" onChange={this.onTextFieldChange('progressColor')} />
             <TextField value={bgColor} label="background color" onChange={this.onTextFieldChange('bgColor')} />
             <TextField value={textColor} label="text color" onChange={this.onTextFieldChange('textColor')} />
@@ -64,6 +67,7 @@ export default class App extends Component <{}, AppState> {
               progressColor={progressColor}
               bgColor={bgColor}
               textColor={textColor}
+              lineWidth={lineWidth}
             />
           </div>
           <div>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "ts-react-toolbox": "^0.0.24"
   },
   "engines": {
-    "node": "^8.5.0"
+    "node": ">=8.5.0"
   },
   "scripts": {
     "start": "webpack -w",

--- a/src/circle.tsx
+++ b/src/circle.tsx
@@ -8,11 +8,11 @@ export interface CircleProps {
   bgColor?: string;
   textColor?: string;
   size?: string;
-  lineWidth?: string; // TODO: Implement
+  lineWidth?: string;
 }
 
 export interface CircleState {
-  
+
 }
 
 const radius = 175;
@@ -26,9 +26,10 @@ export class Circle extends Component<CircleProps, CircleState> {
     progressColor: 'rgb(76, 154, 255)',
     bgColor: '#ecedf0',
     textColor: '#6b778c',
-    size: '100'
+    size: '100',
+    lineWidth: '25'
   }
-  
+
   get text() {
     const {progress, showPercentage, textColor} = this.props;
     if (!showPercentage) return;
@@ -42,13 +43,13 @@ export class Circle extends Component<CircleProps, CircleState> {
 
   render() {
     const {text} = this;
-    const {progress, size, bgColor, progressColor} = this.props;
+    const {progress, size, bgColor, progressColor, lineWidth} = this.props;
     const strokeDashoffset = getOffset(progress);
-    
+
     return (
       <svg width={size} height={size} viewBox="-25 -25 400 400">
-        <circle stroke={bgColor} cx="175" cy="175" r="175" strokeWidth="25" fill="none" />
-        <circle stroke={progressColor} transform="rotate(-90 175 175)" cx="175" cy="175" r="175" strokeDasharray="1100" strokeWidth="25" strokeDashoffset="1100" fill="none" style={{strokeDashoffset, transition: 'stroke-dashoffset 1s ease-out'}} />
+        <circle stroke={bgColor} cx="175" cy="175" r="175" strokeWidth={lineWidth} fill="none" />
+        <circle stroke={progressColor} transform="rotate(-90 175 175)" cx="175" cy="175" r="175" strokeDasharray="1100" strokeWidth={lineWidth} strokeDashoffset="1100" fill="none" style={{strokeDashoffset, transition: 'stroke-dashoffset 1s ease-out'}} />
         {text}
       </svg>
     );


### PR DESCRIPTION
Allows the user to define the stroke width of the circle via a `lineWidth` prop:

```javascript
import Circle from 'react-circle';

<Circle
  size={150}
  lineWidth={14} // Default is 25.
  progress={69}
  progressColor="cornflowerblue"
  bgColor="whitesmoke"
  textColor="hotpink"
/>
```

The `engines` config in `package.json` was changed to allow newer backward compatible environments to install dependencies. Static node versioning is sort of a moot point on this project given the build process.

`README.md` and the example page has been updated to accommodate the change.

