### PR TITLE
Add props to customize percentage symbol and allow style overrides for text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Optionally, you can pass the following props and customize it as your will
 import Circle from 'react-circle';
 
 // All avaliable props for customization:
+// Details are ordered as:
+// <Type>: <Description>
 <Circle
   size={150} // Number: Defines the size of the circle.
   lineWidth={14} // Number: Defines the thickness of the circle's stroke. 
@@ -42,7 +44,7 @@ import Circle from 'react-circle';
   bgColor="whitesmoke" // String: Color of "empty" portion of circle.
   textColor="hotpink" // String: Color of percentage text color.
   textStyle={{ 
-    font: 'bold 5rem Helvetica, Arial, sans-serif' // Object: Custom styling for percentage.
+    font: 'bold 5rem Helvetica, Arial, sans-serif' // CSSProperties: Custom styling for percentage.
   }}
   percentSpacing={10} // Number: Adjust spacing of "%" symbol and number.
   showPercentage={true} // Boolean: Show/hide percentage.

--- a/README.md
+++ b/README.md
@@ -33,12 +33,19 @@ Optionally, you can pass the following props and customize it as your will
 ```javascript
 import Circle from 'react-circle';
 
+// All avaliable props for customization:
 <Circle
-  size={150}
-  lineWidth={14}
-  progress={69}
-  progressColor="cornflowerblue"
-  bgColor="whitesmoke"
-  textColor="hotpink"
+  size={150} // Number: Defines the size of the circle.
+  lineWidth={14} // Number: Defines the thickness of the circle's stroke. 
+  progress={69} // Number: Update to change the progress and percentage.
+  progressColor="cornflowerblue"  // String: Color of "progress" portion of circle.
+  bgColor="whitesmoke" // String: Color of "empty" portion of circle.
+  textColor="hotpink" // String: Color of percentage text color.
+  textStyle={{ 
+    font: 'bold 5rem Helvetica, Arial, sans-serif' // Object: Custom styling for percentage.
+  }}
+  percentSpacing={10} // Number: Adjust spacing of "%" symbol and number.
+  showPercentage={true} // Boolean: Show/hide percentage.
+  showPercentageSymbol={true} // Boolean: Show/hide only the "%" symbol.
 />
 ```

--- a/example/app.tsx
+++ b/example/app.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import {Component} from 'react';
+import { Component } from 'react';
 import FieldRange from '@atlaskit/field-range';
 import TextField from '@atlaskit/field-text';
-import {AppWrapper, TextFieldsWrapper, OptionsWrapper, CircleWrapper} from './styled';
+import { AppWrapper, TextFieldsWrapper, OptionsWrapper, CircleWrapper } from './styled';
 import Circle from '../src';
 
 export interface AppState {
@@ -16,7 +16,7 @@ export interface AppState {
 
 export type StatePropName = 'progressColor' | 'bgColor' | 'textColor' | 'size' | 'lineWidth';
 
-export default class App extends Component <{}, AppState> {
+export default class App extends Component<{}, AppState> {
   state: AppState = {
     progress: 25,
     progressColor: '#F7DC1B',
@@ -27,15 +27,15 @@ export default class App extends Component <{}, AppState> {
   }
 
   onTextFieldChange = (propName: StatePropName) => (e: any) => {
-    this.setState({[propName]: e.target.value} as any);
+    this.setState({ [propName]: e.target.value } as any);
   }
 
   onProgressChange = (progress: number) => {
-    this.setState({progress});
+    this.setState({ progress });
   }
 
   render() {
-    const {progress, progressColor, bgColor, textColor, size, lineWidth} = this.state;
+    const { progress, progressColor, bgColor, textColor, size, lineWidth } = this.state;
 
     return (
       <AppWrapper>
@@ -68,6 +68,7 @@ export default class App extends Component <{}, AppState> {
               bgColor={bgColor}
               textColor={textColor}
               lineWidth={lineWidth}
+              textStyle={{ font: 'bold 5rem Helvetica, Arial, sans-serif' }}
             />
           </div>
           <div>

--- a/src/circle.tsx
+++ b/src/circle.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react';
-import { Component } from 'react';
+import { Component, CSSProperties } from 'react';
 
 export interface CircleProps {
   progress: number;
   showPercentage?: boolean;
-  showPercentageSymbol: boolean;
+  showPercentageSymbol?: boolean;
   progressColor?: string;
   bgColor?: string;
   textColor?: string;
   size?: string;
   lineWidth?: string;
-  percentSpacing: number;
-  textStyle?: object;
+  percentSpacing?: number;
+  textStyle?: CSSProperties;
 }
 
 export interface CircleState {
@@ -32,7 +32,8 @@ export class Circle extends Component<CircleProps, CircleState> {
     textColor: '#6b778c',
     size: '100',
     lineWidth: '25',
-    percentSpacing: 10
+    percentSpacing: 10,
+    textStyle: { font: 'bold 4rem Helvetica, Arial, sans-serif' }
   }
 
   get text() {
@@ -40,7 +41,7 @@ export class Circle extends Component<CircleProps, CircleState> {
     if (!showPercentage) return;
 
     return (
-      <text style={{ font: 'bold 4rem Helvetica, Arial, sans-serif', ...textStyle }} fill={textColor} x="50%" y="50%" dx="-25" textAnchor="middle">
+      <text style={textStyle} fill={textColor} x="50%" y="50%" dx="-25" textAnchor="middle">
         {progress}{showPercentageSymbol && <tspan dx={percentSpacing}>%</tspan>}
       </text>
     );

--- a/src/circle.tsx
+++ b/src/circle.tsx
@@ -1,14 +1,17 @@
 import * as React from 'react';
-import {Component} from 'react';
+import { Component } from 'react';
 
 export interface CircleProps {
   progress: number;
   showPercentage?: boolean;
+  showPercentageSymbol: boolean;
   progressColor?: string;
   bgColor?: string;
   textColor?: string;
   size?: string;
   lineWidth?: string;
+  percentSpacing: number;
+  textStyle?: object;
 }
 
 export interface CircleState {
@@ -23,33 +26,35 @@ export class Circle extends Component<CircleProps, CircleState> {
   static defaultProps: CircleProps = {
     progress: 0,
     showPercentage: true,
+    showPercentageSymbol: true,
     progressColor: 'rgb(76, 154, 255)',
     bgColor: '#ecedf0',
     textColor: '#6b778c',
     size: '100',
-    lineWidth: '25'
+    lineWidth: '25',
+    percentSpacing: 10
   }
 
   get text() {
-    const {progress, showPercentage, textColor} = this.props;
+    const { progress, showPercentage, textColor, textStyle, percentSpacing, showPercentageSymbol } = this.props;
     if (!showPercentage) return;
 
     return (
-      <text style={{font: 'bold 4rem Helvetica, Arial, sans-serif'}} fill={textColor} x="50%" y="50%" dx="-25" textAnchor="middle">
-        {progress} %
+      <text style={{ font: 'bold 4rem Helvetica, Arial, sans-serif', ...textStyle }} fill={textColor} x="50%" y="50%" dx="-25" textAnchor="middle">
+        {progress}{showPercentageSymbol && <tspan dx={percentSpacing}>%</tspan>}
       </text>
     );
   }
 
   render() {
-    const {text} = this;
-    const {progress, size, bgColor, progressColor, lineWidth} = this.props;
+    const { text } = this;
+    const { progress, size, bgColor, progressColor, lineWidth } = this.props;
     const strokeDashoffset = getOffset(progress);
 
     return (
       <svg width={size} height={size} viewBox="-25 -25 400 400">
         <circle stroke={bgColor} cx="175" cy="175" r="175" strokeWidth={lineWidth} fill="none" />
-        <circle stroke={progressColor} transform="rotate(-90 175 175)" cx="175" cy="175" r="175" strokeDasharray="1100" strokeWidth={lineWidth} strokeDashoffset="1100" fill="none" style={{strokeDashoffset, transition: 'stroke-dashoffset 1s ease-out'}} />
+        <circle stroke={progressColor} transform="rotate(-90 175 175)" cx="175" cy="175" r="175" strokeDasharray="1100" strokeWidth={lineWidth} strokeDashoffset="1100" fill="none" style={{ strokeDashoffset, transition: 'stroke-dashoffset 1s ease-out' }} />
         {text}
       </svg>
     );


### PR DESCRIPTION
Hi Hector,

Thank you for allowing me permissions to put this up and for merging my earlier PR. 
I've done some further work that introduces more customization of the circle. 

This update introduces three new props:
- Text styling override for percentage text. 
Ex. `textStyle={{...styles}}`
- The ability to the hide the percentage symbol. 
Ex. `showPercentageSymbol={true}` 
- The ability to adjust the spacing of the percentage symbol and percentage value. 
Ex. `percentSpacing={10}`

You can override the default text styling for the percentage symbol by using `textStyle`:
```js
<Circle
  textStyle={{ 
    font: 'bold 2rem Helvetica, Arial, sans-serif' 
  }}
/>
```
If `textStyle` is not defined as a prop, the default styles are used instead. 
This allows users to use a font of their choice for the percentage text or adjust the font size.

The `showPercentageSymbol` prop shows or hides the percent symbol. Defaults to `true`.

The `percentSpacing` prop changes the spacing of the percent symbol and the value. 
Defaults to `10`, creating a slight space between them.

I've also updated the `README` to show how these props are used and listed what datatype to pass into each prop provided by the API. Let me know if anything needs to be changed. 👌

