### PR TITLE
Rounded line caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ import Circle from 'react-circle';
     font: 'bold 5rem Helvetica, Arial, sans-serif' // CSSProperties: Custom styling for percentage.
   }}
   percentSpacing={10} // Number: Adjust spacing of "%" symbol and number.
+  roundedStroke={true} // Boolean: Rounded/Flat line ends
   showPercentage={true} // Boolean: Show/hide percentage.
   showPercentageSymbol={true} // Boolean: Show/hide only the "%" symbol.
 />

--- a/example/app.tsx
+++ b/example/app.tsx
@@ -62,6 +62,7 @@ export default class App extends Component<{}, AppState> {
           <div>
             <h1>Custom</h1>
             <Circle
+              roundedStroke
               size={size}
               progress={progress}
               progressColor={progressColor}

--- a/src/circle.tsx
+++ b/src/circle.tsx
@@ -12,6 +12,7 @@ export interface CircleProps {
   lineWidth?: string;
   percentSpacing?: number;
   textStyle?: CSSProperties;
+  roundedStroke?: boolean;
 }
 
 export interface CircleState {
@@ -49,13 +50,13 @@ export class Circle extends Component<CircleProps, CircleState> {
 
   render() {
     const { text } = this;
-    const { progress, size, bgColor, progressColor, lineWidth } = this.props;
+    const { progress, size, bgColor, progressColor, lineWidth, roundedStroke} = this.props;
     const strokeDashoffset = getOffset(progress);
-
+    const strokeLinecap = roundedStroke ? 'round' : 'butt';
     return (
       <svg width={size} height={size} viewBox="-25 -25 400 400">
-        <circle stroke={bgColor} cx="175" cy="175" r="175" strokeWidth={lineWidth} fill="none" />
-        <circle stroke={progressColor} transform="rotate(-90 175 175)" cx="175" cy="175" r="175" strokeDasharray="1100" strokeWidth={lineWidth} strokeDashoffset="1100" fill="none" style={{ strokeDashoffset, transition: 'stroke-dashoffset 1s ease-out' }} />
+        <circle stroke={bgColor} cx="175" cy="175" r="175" strokeWidth={lineWidth} fill="none"/>
+        <circle stroke={progressColor} transform="rotate(-90 175 175)" cx="175" cy="175" r="175" strokeDasharray="1100" strokeWidth={lineWidth} strokeDashoffset="1100" strokeLinecap={strokeLinecap} fill="none"  style={{ strokeDashoffset, transition: 'stroke-dashoffset 1s ease-out' }} />
         {text}
       </svg>
     );


### PR DESCRIPTION
Added rounded option to render end of progress line in a rounded fashion.

Didn't include it in the examples with a checkbox beacuse of: #7 issues.