### PR TITLE
add onAnimationEnd event handler

### DIFF
--- a/__tests__/index.tsx
+++ b/__tests__/index.tsx
@@ -69,8 +69,16 @@ describe('ReactCircle', () => {
   })
 
   it('Should render with .25 second animation duration', () => {
-    const { circle } = setup({animationDuration:'.25s');
+    const { circle } = setup({animationDuration:'.25s'});
     const innerCircle = circle.find('circle').last()
     expect(innerCircle.prop('style').transition).toMatch(/.25s/)
   })
+
+  it('Should call onAnimationEnd event handler', () => {
+    const onAnimationEnd = jest.fn();
+    const { circle } = setup({onAnimationEnd});
+    const innerCircle = circle.find('circle').last();
+    innerCircle.simulate('transitionend');
+    expect(onAnimationEnd).toBeCalled();
+  });
 });

--- a/example/app.tsx
+++ b/example/app.tsx
@@ -84,14 +84,14 @@ export default class App extends Component<{}, AppState> {
             <TextField value={textColor} label="text color" onChange={this.onTextFieldChange('textColor')} />
             <CheckBoxWrapper>
               <Checkbox
-                initiallyChecked={true} 
-                label="Animation" 
-                onChange={this.onCheckboxChange('animated')} 
+                initiallyChecked={true}
+                label="Animation"
+                onChange={this.onCheckboxChange('animated')}
               />
               <Checkbox
                 initiallyChecked={true}
-                label="Rounded stroke" 
-                onChange={this.onCheckboxChange('roundedStroke')} 
+                label="Rounded stroke"
+                onChange={this.onCheckboxChange('roundedStroke')}
               />
                 <Checkbox
                   initiallyChecked={true}
@@ -103,14 +103,14 @@ export default class App extends Component<{}, AppState> {
           <Button
               appearance="primary"
               shouldFitContainer
-              onClick={this.onCheckboxChange('defaultMode')} 
+              onClick={this.onCheckboxChange('defaultMode')}
             >
               {defaultMode ? 'DEFAULT' : 'CUSTOM'}
             </Button>
         </OptionsWrapper>
           </OptionsSidebar>
         <CircleWrapper>
-            {!defaultMode ? 
+            {!defaultMode ?
             <Circle
               responsive={responsive}
               animate={animated}
@@ -122,6 +122,7 @@ export default class App extends Component<{}, AppState> {
               textColor={textColor}
               lineWidth={lineWidth}
               textStyle={{ font: 'bold 5rem Helvetica, Arial, sans-serif' }}
+              onAnimationEnd={() => { console.log('onAnimationEnd'); }}
             />
               : <Circle progress={35}/>
             }

--- a/src/circle.tsx
+++ b/src/circle.tsx
@@ -16,6 +16,7 @@ export interface CircleProps {
   textStyle?: CSSProperties;
   roundedStroke?: boolean;
   responsive?: boolean;
+  onAnimationEnd?(): void;
 }
 
 export interface CircleState {
@@ -64,7 +65,7 @@ export class Circle extends Component<CircleProps, CircleState> {
     return (
       <svg width={svgSize} height={svgSize} viewBox="-25 -25 400 400">
         <circle stroke={bgColor} cx="175" cy="175" r="175" strokeWidth={lineWidth} fill="none"/>
-        <circle stroke={progressColor} transform="rotate(-90 175 175)" cx="175" cy="175" r="175" strokeDasharray="1100" strokeWidth={lineWidth} strokeDashoffset="1100" strokeLinecap={strokeLinecap} fill="none" style={{ strokeDashoffset, transition }} />
+        <circle stroke={progressColor} transform="rotate(-90 175 175)" cx="175" cy="175" r="175" strokeDasharray="1100" strokeWidth={lineWidth} strokeDashoffset="1100" strokeLinecap={strokeLinecap} fill="none" style={{ strokeDashoffset, transition }} onTransitionEnd={this.props.onAnimationEnd}/>
         {text}
       </svg>
     );

--- a/src/circle.tsx
+++ b/src/circle.tsx
@@ -56,7 +56,7 @@ export class Circle extends Component<CircleProps, CircleState> {
 
   render() {
     const { text } = this;
-    const { progress, size, bgColor, progressColor, lineWidth, animate, animationDuration, roundedStroke, responsive } = this.props;
+    const { progress, size, bgColor, progressColor, lineWidth, animate, animationDuration, roundedStroke, responsive, onAnimationEnd } = this.props;
     const strokeDashoffset = getOffset(progress);
     const transition = animate ? `stroke-dashoffset ${animationDuration} ease-out` : null;
     const strokeLinecap = roundedStroke ? 'round' : 'butt';
@@ -65,7 +65,7 @@ export class Circle extends Component<CircleProps, CircleState> {
     return (
       <svg width={svgSize} height={svgSize} viewBox="-25 -25 400 400">
         <circle stroke={bgColor} cx="175" cy="175" r="175" strokeWidth={lineWidth} fill="none"/>
-        <circle stroke={progressColor} transform="rotate(-90 175 175)" cx="175" cy="175" r="175" strokeDasharray="1100" strokeWidth={lineWidth} strokeDashoffset="1100" strokeLinecap={strokeLinecap} fill="none" style={{ strokeDashoffset, transition }} onTransitionEnd={this.props.onAnimationEnd}/>
+        <circle stroke={progressColor} transform="rotate(-90 175 175)" cx="175" cy="175" r="175" strokeDasharray="1100" strokeWidth={lineWidth} strokeDashoffset="1100" strokeLinecap={strokeLinecap} fill="none" style={{ strokeDashoffset, transition }} onTransitionEnd={onAnimationEnd}/>
         {text}
       </svg>
     );


### PR DESCRIPTION
I use react-circle on performing time-consuming tasks. In my app, it only appears when tasks work in progress, dismissing immediately after tasks are finished.

In this case, `onAnimationEnd` is useful to await animation. Otherwise, the circle disappears before 100%.