### PR TITLE
fix text verticle alignment

### DIFF
--- a/src/circle.tsx
+++ b/src/circle.tsx
@@ -48,7 +48,7 @@ export class Circle extends Component<CircleProps, CircleState> {
     if (!showPercentage) return;
 
     return (
-      <text style={textStyle} fill={textColor} x="50%" y="50%" dx="-25" textAnchor="middle">
+      <text style={textStyle} fill={textColor} x={radius} y={radius} textAnchor="middle" dominantBaseline="central">
         {progress}{showPercentageSymbol && <tspan dx={percentSpacing}>%</tspan>}
       </text>
     );


### PR DESCRIPTION
The current alignment is not so accurate and a text big enough will make it more obvious, like

![former](https://user-images.githubusercontent.com/29633025/45404719-ac7aa780-b692-11e8-815a-335082fe9d7e.png)

I think dominantBaseline is a better choice, and it turns out, like

![central](https://user-images.githubusercontent.com/29633025/45404761-e0ee6380-b692-11e8-92e2-ee1a8d8009d9.png)
