### PR TITLE
fix compatibilities for IE/MSEdge

### DIFF
--- a/src/circle.tsx
+++ b/src/circle.tsx
@@ -43,9 +43,37 @@ export class Circle extends Component<CircleProps, CircleState> {
     textStyle: { font: 'bold 4rem Helvetica, Arial, sans-serif' }
   }
 
+  /**
+   * @desc Some browers (like IE/Edge) don't support dominant-baseLine.
+   *       It detects whether in Chrome/Firefox/Safari which has been tested to support it,
+   *       and takes all other circumstances as not supported and use the workaround instead.
+   * @ref https://github.com/arasatasaygin/is.js/blob/master/is.js
+   */
+  get dominantBaselineSupported () {
+    const W = window as any;
+    if (W.dominantBaselineSupported === void 0) {
+      const ua = navigator.userAgent.toLowerCase()
+      const supportedPatterns = [
+        /(?:chrome|crios)\/(\d+)/,
+        /(?:firefox|fxios)\/(\d+)/,
+        /version\/(\d+).+?safari/
+      ];
+
+      W.dominantBaselineSupported = supportedPatterns.some(p => !!ua.match(p));
+    }
+
+    return W.dominantBaselineSupported;
+  }
+
   get text() {
     const { progress, showPercentage, textColor, textStyle, percentSpacing, showPercentageSymbol } = this.props;
     if (!showPercentage) return;
+
+    if (!this.dominantBaselineSupported) return (
+      <text style={textStyle} fill={textColor} x={radius} y={radius} dy="0.33em" textAnchor="middle">
+        {progress}{showPercentageSymbol && <tspan dx={percentSpacing}>%</tspan>}
+      </text>
+    );
 
     return (
       <text style={textStyle} fill={textColor} x={radius} y={radius} textAnchor="middle" dominantBaseline="central">


### PR DESCRIPTION
I found `0.33em` perfect for fallbacks as it's supported in all browsers and just works. I'm considering it might be even better than `dominant-baseline`, what do you think about it ?

![fallback](https://user-images.githubusercontent.com/29633025/45605341-fd154a80-ba6e-11e8-9ed9-b07d77dca2be.png)
![fallback2](https://user-images.githubusercontent.com/29633025/45605344-fedf0e00-ba6e-11e8-9aa0-b8d4414e8660.png)

