### PR TITLE
Feature/example button styling

### DIFF
--- a/example/app.tsx
+++ b/example/app.tsx
@@ -65,50 +65,50 @@ export default class App extends Component<{}, AppState> {
       <AppWrapper>
         {ghLink}
         <OptionsSidebar>
-        <Button
-            appearance="primary"
-            shouldFitContainer
-            onClick={this.onCheckboxChange('defaultMode')}
-          >
-            {defaultMode ? 'DEFAULT' : 'CUSTOM'}
-          </Button>
-        <OptionsWrapper disabled={defaultMode}>
-          <div>
-            <div>Percentage</div>
-            <input
-              type="range"
-              value={progress}
-              min={0}
-              max={100}
-              onChange={this.onProgressChange}
-            />
-          </div>
-          <TextFieldsWrapper>
-            <TextField value={size} label="width" onChange={this.onTextFieldChange('size')} />
-            <TextField value={lineWidth} label="line width" onChange={this.onTextFieldChange('lineWidth')} />
-            <TextField value={progressColor} label="progress color" onChange={this.onTextFieldChange('progressColor')} />
-            <TextField value={bgColor} label="background color" onChange={this.onTextFieldChange('bgColor')} />
-            <TextField value={textColor} label="text color" onChange={this.onTextFieldChange('textColor')} />
-            <CheckBoxWrapper>
-              <Checkbox
-                initiallyChecked={true}
-                label="Animation"
-                onChange={this.onCheckboxChange('animated')}
+          <OptionsWrapper disabled={defaultMode}>
+            <Button
+              appearance="primary"
+              shouldFitContainer
+              onClick={this.onCheckboxChange('defaultMode')}
+              >
+                {defaultMode ? 'DEFAULT' : 'CUSTOM'}
+              </Button>
+            <div>
+              <div>Percentage</div>
+              <input
+                type="range"
+                value={progress}
+                min={0}
+                max={100}
+                onChange={this.onProgressChange}
               />
-              <Checkbox
-                initiallyChecked={true}
-                label="Rounded stroke"
-                onChange={this.onCheckboxChange('roundedStroke')}
-              />
+            </div>
+            <TextFieldsWrapper>
+              <TextField value={size} label="width" onChange={this.onTextFieldChange('size')} />
+              <TextField value={lineWidth} label="line width" onChange={this.onTextFieldChange('lineWidth')} />
+              <TextField value={progressColor} label="progress color" onChange={this.onTextFieldChange('progressColor')} />
+              <TextField value={bgColor} label="background color" onChange={this.onTextFieldChange('bgColor')} />
+              <TextField value={textColor} label="text color" onChange={this.onTextFieldChange('textColor')} />
+              <CheckBoxWrapper>
                 <Checkbox
                   initiallyChecked={true}
-                  label="Responsive"
-                  onChange={this.onCheckboxChange('responsive')}
+                  label="Animation"
+                  onChange={this.onCheckboxChange('animated')}
                 />
-            </CheckBoxWrapper>
-          </TextFieldsWrapper>
-        </OptionsWrapper>
-          </OptionsSidebar>
+                <Checkbox
+                  initiallyChecked={true}
+                  label="Rounded stroke"
+                  onChange={this.onCheckboxChange('roundedStroke')}
+                />
+                  <Checkbox
+                    initiallyChecked={true}
+                    label="Responsive"
+                    onChange={this.onCheckboxChange('responsive')}
+                  />
+              </CheckBoxWrapper>
+            </TextFieldsWrapper>
+          </OptionsWrapper>
+        </OptionsSidebar>
         <CircleWrapper>
             {!defaultMode ?
             <Circle

--- a/example/app.tsx
+++ b/example/app.tsx
@@ -65,6 +65,13 @@ export default class App extends Component<{}, AppState> {
       <AppWrapper>
         {ghLink}
         <OptionsSidebar>
+        <Button
+            appearance="primary"
+            shouldFitContainer
+            onClick={this.onCheckboxChange('defaultMode')}
+          >
+            {defaultMode ? 'DEFAULT' : 'CUSTOM'}
+          </Button>
         <OptionsWrapper disabled={defaultMode}>
           <div>
             <div>Percentage</div>
@@ -100,13 +107,6 @@ export default class App extends Component<{}, AppState> {
                 />
             </CheckBoxWrapper>
           </TextFieldsWrapper>
-          <Button
-              appearance="primary"
-              shouldFitContainer
-              onClick={this.onCheckboxChange('defaultMode')}
-            >
-              {defaultMode ? 'DEFAULT' : 'CUSTOM'}
-            </Button>
         </OptionsWrapper>
           </OptionsSidebar>
         <CircleWrapper>

--- a/example/styled.ts
+++ b/example/styled.ts
@@ -32,11 +32,18 @@ export const AppWrapper = styled.div`
 `;
 
 export const OptionsWrapper = styled.div`
-  ${(props: OptionsWrapperProps) => props.disabled ? css`
-  opacity:.4;
-  pointer-events: none;
-  ` : ''
-}
+  ${css`
+    ${(props:OptionsWrapperProps)=>props.disabled?`
+      > div {
+        opacity:.4;
+        pointer-events: none;
+      }
+    `:''}
+    margin-top: 2em;
+      > :last-child {
+        margin-bottom: 2em;
+      }
+    `}
 `;
 
 export const CircleWrapper = styled.div`
@@ -51,15 +58,14 @@ export const OptionsSidebar = styled.div`
   width:30%;
   display:flex;
   flex-direction:column;
-  padding:3em;
   border-right: 1px solid #e2e2e2;
+  padding: 2em;
   overflow: auto;
 `;
 
 export const TextFieldsWrapper = styled.div`
   display: flex;
   justify-content: space-around;
-  display:flex;
   flex-direction:column;
 `;
 

--- a/example/styled.ts
+++ b/example/styled.ts
@@ -39,8 +39,10 @@ export const OptionsWrapper = styled.div`
         pointer-events: none;
       }
     `:''}
-    margin-top: 2em;
-      > :last-child {
+      > button {
+        margin-bottom: 2em;        
+      }
+      >:last-child {
         margin-bottom: 2em;
       }
     `}


### PR DESCRIPTION
When clicking the button in the example the button subsequently becomes disabled.
This PR updates the example to disable the child div elements rather than the parent wrapper.

I also reduced the padding, added a margin to maintain consistent spacing when scrolling to the bottom and moved the main button to the top as it was not friendly for lower resolution displays such as my laptop where most of the controls would be hidden on load:

![image](https://user-images.githubusercontent.com/10459377/46568382-3f9fb800-c987-11e8-93bb-7cd5d7064c9d.png)

![image](https://user-images.githubusercontent.com/10459377/46568381-357db980-c987-11e8-9fc7-e40b692e83b9.png)

