### PR TITLE
Feature/render props custom layout

### DIFF
--- a/__tests__/__snapshots__/index.tsx.snap
+++ b/__tests__/__snapshots__/index.tsx.snap
@@ -3,13 +3,13 @@
 exports[`ReactCircle Should default render with animation 1`] = `
 Object {
   "strokeDashoffset": 825,
-  "transition": null,
+  "transition": undefined,
 }
 `;
 
 exports[`ReactCircle Should render without animation 1`] = `
 Object {
   "strokeDashoffset": 825,
-  "transition": null,
+  "transition": undefined,
 }
 `;

--- a/example/app.tsx
+++ b/example/app.tsx
@@ -16,7 +16,7 @@ export interface AppState {
   animated: boolean;
   roundedStroke: boolean;
   responsive: boolean;
-  defaultMode: boolean;
+  mode: number;
 }
 
 export type StatePropName = keyof AppState;
@@ -42,7 +42,7 @@ export default class App extends Component<{}, AppState> {
     animated: true,
     roundedStroke: true,
     responsive: true,
-    defaultMode: false,
+    mode: 0,
   }
 
   onTextFieldChange = (propName: StatePropName) => (e: any) => {
@@ -58,14 +58,18 @@ export default class App extends Component<{}, AppState> {
     this.setState({ [propName]: !currentValue } as any);
   }
 
+  onModeChange = () => {
+    this.setState(state=>({mode:(state.mode+1)%3}));
+  }
+
   render() {
-    const { progress, progressColor, bgColor, textColor, size, lineWidth, animated, roundedStroke, responsive, defaultMode} = this.state;
+    const { progress, progressColor, bgColor, textColor, size, lineWidth, animated, roundedStroke, responsive, mode} = this.state;
 
     return (
       <AppWrapper>
         {ghLink}
         <OptionsSidebar>
-        <OptionsWrapper disabled={defaultMode}>
+        <OptionsWrapper disabled={!mode}>
           <div>
             <div>Percentage</div>
             <input
@@ -100,18 +104,19 @@ export default class App extends Component<{}, AppState> {
                 />
             </CheckBoxWrapper>
           </TextFieldsWrapper>
-          <Button
-              appearance="primary"
-              shouldFitContainer
-              onClick={this.onCheckboxChange('defaultMode')}
-            >
-              {defaultMode ? 'DEFAULT' : 'CUSTOM'}
-            </Button>
         </OptionsWrapper>
+        <Button
+          appearance="primary"
+          shouldFitContainer
+          onClick={this.onModeChange}
+          >
+            {mode > 1 ? 'CUSTOM RENDER' : (mode > 0 ? 'CUSTOM' : 'DEFAULT')}
+          </Button>
           </OptionsSidebar>
         <CircleWrapper>
-            {!defaultMode ?
-            <Circle
+            {mode === 0
+              ? <Circle progress={35}/>
+              : <Circle
               responsive={responsive}
               animate={animated}
               roundedStroke={roundedStroke}
@@ -123,9 +128,14 @@ export default class App extends Component<{}, AppState> {
               lineWidth={lineWidth}
               textStyle={{ font: 'bold 5rem Helvetica, Arial, sans-serif' }}
               onAnimationEnd={() => { console.log('onAnimationEnd'); }}
-            />
-              : <Circle progress={35}/>
-            }
+            >{mode === 2 ? ({circle, progressCircle}) => <svg width={responsive?'100%':size} height={responsive?'100%':size} viewBox="-25 -25 400 400">
+                <text x="25%" y="25%" style={{fontSize:50}}>{Math.round(60-(60*progress/100))} mins</text>
+                <text x="30%" y="50%" style={{fontSize:80,transformOrigin:'175px 175px 0px',transform:`rotate(${360*progress/100}deg)`}}>🕛</text>
+                <text x="20%" y="65%" style={{fontSize:45}}>remaining</text>
+                {circle}
+                {progressCircle}
+              </svg> : undefined}
+            </Circle>}
         </CircleWrapper>
       </AppWrapper>
     )

--- a/src/circle.tsx
+++ b/src/circle.tsx
@@ -17,6 +17,7 @@ export interface CircleProps {
   roundedStroke?: boolean;
   responsive?: boolean;
   onAnimationEnd?(): void;
+  children?: (<T>(parts:any) => React.ReactElement<T>)|React.ReactNode;
 }
 
 export interface CircleState {
@@ -43,7 +44,7 @@ export class Circle extends Component<CircleProps, CircleState> {
     textStyle: { font: 'bold 4rem Helvetica, Arial, sans-serif' }
   }
 
-  get text() {
+  get progressText() {
     const { progress, showPercentage, textColor, textStyle, percentSpacing, showPercentageSymbol } = this.props;
     if (!showPercentage) return;
 
@@ -54,20 +55,32 @@ export class Circle extends Component<CircleProps, CircleState> {
     );
   }
 
-  render() {
-    const { text } = this;
-    const { progress, size, bgColor, progressColor, lineWidth, animate, animationDuration, roundedStroke, responsive, onAnimationEnd } = this.props;
+  get circle() {
+    const { bgColor, lineWidth } = this.props;
+    return <circle stroke={bgColor} cx="175" cy="175" r="175" strokeWidth={lineWidth} fill="none"/>
+  }
+
+  get progressCircle() {
+    const { progress, progressColor, lineWidth, animate, animationDuration, roundedStroke, onAnimationEnd } = this.props;
     const strokeDashoffset = getOffset(progress);
     const transition = animate ? `stroke-dashoffset ${animationDuration} ease-out` : undefined;
     const strokeLinecap = roundedStroke ? 'round' : 'butt';
-    const svgSize = responsive ? '100%' : size;
+    return <circle stroke={progressColor} transform="rotate(-90 175 175)" cx="175" cy="175" r="175" strokeDasharray="1100" strokeWidth={lineWidth} strokeDashoffset="1100" strokeLinecap={strokeLinecap} fill="none" style={{ strokeDashoffset, transition }} onTransitionEnd={onAnimationEnd}/>
+  }
 
-    return (
-      <svg width={svgSize} height={svgSize} viewBox="-25 -25 400 400">
-        <circle stroke={bgColor} cx="175" cy="175" r="175" strokeWidth={lineWidth} fill="none"/>
-        <circle stroke={progressColor} transform="rotate(-90 175 175)" cx="175" cy="175" r="175" strokeDasharray="1100" strokeWidth={lineWidth} strokeDashoffset="1100" strokeLinecap={strokeLinecap} fill="none" style={{ strokeDashoffset, transition }} onTransitionEnd={onAnimationEnd}/>
-        {text}
-      </svg>
-    );
+  render() {
+    const { progressText, circle, progressCircle } = this;
+    const { size, responsive } = this.props
+    const svgSize = responsive ? '100%' : size;
+    const renderPropMode = typeof(this.props.children)==='function';
+
+    return renderPropMode
+          ? (this.props.children as Function)({circle,progressCircle,progressText})
+          : <svg width={svgSize} height={svgSize} viewBox="-25 -25 400 400">
+              {circle}
+              {progressCircle}
+              {progressText}
+              {this.props.children}
+            </svg>;
   }
 }

--- a/src/circle.tsx
+++ b/src/circle.tsx
@@ -58,7 +58,7 @@ export class Circle extends Component<CircleProps, CircleState> {
     const { text } = this;
     const { progress, size, bgColor, progressColor, lineWidth, animate, animationDuration, roundedStroke, responsive, onAnimationEnd } = this.props;
     const strokeDashoffset = getOffset(progress);
-    const transition = animate ? `stroke-dashoffset ${animationDuration} ease-out` : null;
+    const transition = animate ? `stroke-dashoffset ${animationDuration} ease-out` : undefined;
     const strokeLinecap = roundedStroke ? 'round' : 'butt';
     const svgSize = responsive ? '100%' : size;
 


### PR DESCRIPTION
Had a crack at #13 - added a render prop option as suggested and updated example.

I decided to exclude the svg element in this mode as the circle fills the svg dimensions and this defeats some of the customisation afforded because it leaves no space for other elements.

``<Circle>
({circle, progressCircle, progressText}) => <svg width={responsive?'100%':size} height={responsive?'100%':size} viewBox="-25 -25 400 400">
                <text x="25%" y="25%" style={{fontSize:50}}>{Math.round(60-(60*progress/100))} mins</text>
                <text x="30%" y="50%" style={{fontSize:80,transformOrigin:'175px 175px 0px',transform:`rotate(${360*progress/100}deg)`}}>🕛</text>
                <text x="20%" y="65%" style={{fontSize:45}}>remaining</text>
                {circle}
                {progressCircle}
              </svg>
</Circle>``

![Custom render function](https://user-images.githubusercontent.com/10459377/46572286-8234b500-c9c6-11e8-8569-0d229584eac9.png)

This change also allows other arbitrary svg elements to be added simply by including them inside <Circle> e.g.

`<Circle><text style="font-size;font-size: 30px;" x="25%" y="25%">Completion</text></Circle>`
![Custom elements](https://user-images.githubusercontent.com/10459377/46572314-071fce80-c9c7-11e8-9952-82e88bf31ed8.png)
