### PR TITLE
add Math.min to cap percent at 100%

### DIFF
--- a/__tests__/index.tsx
+++ b/__tests__/index.tsx
@@ -1,6 +1,14 @@
+/**
+ * @jest-environment node
+ */
+
 import * as React from 'react';
-import { shallow, render, mount } from 'enzyme';
+import { shallow, configure } from 'enzyme';
 import Circle, {CircleProps} from '../src';
+
+const Adapter = require("enzyme-adapter-react-16");
+
+configure({ adapter: new Adapter() });
 
 describe('ReactCircle', () => {
   const setup = (props?: Partial<CircleProps>) => {
@@ -80,5 +88,11 @@ describe('ReactCircle', () => {
     const innerCircle = circle.find('circle').last();
     innerCircle.simulate('transitionend');
     expect(onAnimationEnd).toBeCalled();
+  });
+
+  it('Should render a full circle if progress is above 100%', () => {
+    const { circle } = setup({ progress: 120 });
+    const innerCircle = circle.find('circle').last()
+    expect(innerCircle.prop('style').strokeDashoffset).toBe(0)
   });
 });

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
     "@atlaskit/button": "^7.0.2",
     "@atlaskit/checkbox": "^2.0.0",
     "@atlaskit/field-text": "^4.3.0",
+    "enzyme": "^3.8.0",
+    "enzyme-adapter-react-16": "^1.9.1",
     "styled-components": "^3.2.3",
     "ts-react-toolbox": "^0.0.46"
   },

--- a/src/circle.tsx
+++ b/src/circle.tsx
@@ -25,7 +25,7 @@ export interface CircleState {
 
 const radius = 175;
 const diameter = Math.round(Math.PI * radius * 2);
-const getOffset = (val = 0) => Math.round((100 - val) / 100 * diameter);
+const getOffset = (val = 0) => Math.round((100 - Math.min(val, 100)) / 100 * diameter);
 
 export class Circle extends Component<CircleProps, CircleState> {
   static defaultProps: CircleProps = {


### PR DESCRIPTION
This fixes #35 😊

If the percentage is over 100%, the stroke offset will always be full.